### PR TITLE
make stb_image stb_image_write stb_truetype definitions static

### DIFF
--- a/Sources/CStbImage/image_io.c
+++ b/Sources/CStbImage/image_io.c
@@ -1,8 +1,10 @@
 #include "CStbImage.h"
 
 #define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
 #include "stb_image.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_STATIC
 #include "stb_image_write.h"
 
 unsigned char* load_image(const char* path, int* width, int* height, int* channels, int desired_channels){

--- a/Sources/CStbImage/truetype.c
+++ b/Sources/CStbImage/truetype.c
@@ -1,5 +1,5 @@
 #define STB_TRUETYPE_IMPLEMENTATION
-//#define STBTT_STATIC
+#define STBTT_STATIC
 #include "stb_truetype.h"
 
 #include "CStbImage.h"


### PR DESCRIPTION
Thanks for putting this up.

I used another C library in my Swift project which contained stb_image.h and stb_truetype.h as well. This lead to a build failure. Making the definitions of these two libraries static fixed the problem.