### PR TITLE
Method for saving image into a Data BLOB

### DIFF
--- a/Sources/CStbImage/image_io.c
+++ b/Sources/CStbImage/image_io.c
@@ -27,3 +27,15 @@ int write_image_jpg(const char* path, int width, int height, int bpp, const void
 int write_image_png(const char* path, int width, int height, int bpp, const void* data) {
     return stbi_write_png(path, width, height, bpp, data, width*bpp);
 }
+
+int write_image_bmp_to_func(write_func* func, void * context, int width, int height, int bpp, const void* data) {
+    return stbi_write_bmp_to_func(func, context, width, height, bpp, data);
+}
+
+int write_image_jpg_to_func(write_func* func, void * context, int width, int height, int bpp, const void* data, int quality) {
+    return stbi_write_jpg_to_func(func, context, width, height, bpp, data, quality);
+}
+
+int write_image_png_to_func(write_func* func, void* context, int width, int height, int bpp, const void* data) {
+    return stbi_write_png_to_func(func, context, width, height, bpp, data, width*bpp);
+}

--- a/Sources/CStbImage/include/CStbImage.h
+++ b/Sources/CStbImage/include/CStbImage.h
@@ -16,6 +16,11 @@ extern "C" {
     int write_image_jpg(const char* path, int width, int height, int bpp, const void* data, int quality);
     int write_image_png(const char* path, int width, int height, int bpp, const void* data);
 
+    typedef void write_func(void *context, void *data, int size);
+    int write_image_bmp_to_func(write_func* func, void* context, int width, int height, int bpp, const void* data);
+    int write_image_jpg_to_func(write_func* func, void* context, int width, int height, int bpp, const void* data, int quality);
+    int write_image_png_to_func(write_func* func, void* context, int width, int height, int bpp, const void* data);
+
     // Text
     int get_number_of_fonts(const unsigned char* bytes);
     int init_font(stbtt_fontinfo* info, const unsigned char* bytes, int index);

--- a/Sources/Swim/IO/DataImage.swift
+++ b/Sources/Swim/IO/DataImage.swift
@@ -3,7 +3,7 @@ import CStbImage
 
 // MARK: Utilities
 @inlinable
-func inscribe<P: AlphaImageFileFormat>(image: Image<P, UInt8>) throws -> Data {
+func fileData<P: AlphaImageFileFormat>(image: Image<P, UInt8>) throws -> Data {
     let width = Int32(image.width)
     let height = Int32(image.height)
     let bpp = Int32(P.channels)
@@ -11,7 +11,7 @@ func inscribe<P: AlphaImageFileFormat>(image: Image<P, UInt8>) throws -> Data {
     var content = Data()
     
     let code = image.data.withUnsafeBufferPointer {
-        write_image_png_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+        write_image_png_to_func(storeContent, &content, width, height, bpp, $0.baseAddress!)
     }
 
     guard code != 0 else {
@@ -22,7 +22,7 @@ func inscribe<P: AlphaImageFileFormat>(image: Image<P, UInt8>) throws -> Data {
 }
 
 @inlinable
-func inscribe<P: ImageFileFormat>(image: Image<P, UInt8>, format: WriteFormat) throws -> Data {
+func fileData<P: ImageFileFormat>(image: Image<P, UInt8>, format: WriteFormat) throws -> Data {
     let width = Int32(image.width)
     let height = Int32(image.height)
     let bpp = Int32(P.channels)
@@ -33,18 +33,18 @@ func inscribe<P: ImageFileFormat>(image: Image<P, UInt8>, format: WriteFormat) t
     switch format {
     case .bitmap:
         code = image.data.withUnsafeBufferPointer {
-            write_image_bmp_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+            write_image_bmp_to_func(storeContent, &content, width, height, bpp, $0.baseAddress!)
         }
     case let .jpeg(quality):
         guard (1...100).contains(quality) else {
             throw ImageWriteError.qualityOutOfRange
         }
         code = image.data.withUnsafeBufferPointer {
-            write_image_jpg_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!, Int32(quality))
+            write_image_jpg_to_func(storeContent, &content, width, height, bpp, $0.baseAddress!, Int32(quality))
         }
     case .png:
         code = image.data.withUnsafeBufferPointer {
-            write_image_png_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+            write_image_png_to_func(storeContent, &content, width, height, bpp, $0.baseAddress!)
         }
     }
     
@@ -56,8 +56,8 @@ func inscribe<P: ImageFileFormat>(image: Image<P, UInt8>, format: WriteFormat) t
 }
 
 @inlinable
-func inscribe(context: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?, size: Int32) -> Void {
-    guard data != nil &&  context != nil else { return }
+func storeContent(context: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?, size: Int32) -> Void {
+    guard data != nil && context != nil else { return }
 
     let chunk = Data(bytes: data!, count: Int(size))
 
@@ -69,8 +69,8 @@ func inscribe(context: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?,
 extension Image where P: AlphaImageFileFormat, T == UInt8 {
     /// Returns a `Data` containing representation of the image encoded in PNG format.
     @inlinable
-    public func inscribe() throws -> Data {
-        try Swim.inscribe(image: self)
+    public func fileData() throws -> Data {
+        try Swim.fileData(image: self)
     }
 }
 
@@ -79,8 +79,8 @@ extension Image where P: ImageFileFormat, T == UInt8 {
     ///
     /// - Parameter format: Image data format. Defaults to PNG.
     @inlinable
-    public func inscribe(format: WriteFormat = .png) throws -> Data {
-        try Swim.inscribe(image: self, format: format)
+    public func fileData(format: WriteFormat = .png) throws -> Data {
+        try Swim.fileData(image: self, format: format)
     }
 }
 
@@ -91,8 +91,8 @@ extension Image where P: AlphaImageFileFormat, T: BinaryFloatingPoint {
     /// All pixel values are assumed to be in [0, 1] range.
     /// Values outside the range will be clipped.
     @inlinable
-    public func inscribe() throws -> Data {
-        return try convertPixelValue(image: self).inscribe()
+    public func fileData() throws -> Data {
+        return try convertPixelValue(image: self).fileData()
     }
 }
 
@@ -104,7 +104,7 @@ extension Image where P: ImageFileFormat, T: BinaryFloatingPoint {
     ///
     /// - Parameter format: Image data format. Defaults to PNG.
     @inlinable
-    public func inscribe(format: WriteFormat = .png) throws -> Data {
-        return try convertPixelValue(image: self).inscribe(format: format)
+    public func fileData(format: WriteFormat = .png) throws -> Data {
+        return try convertPixelValue(image: self).fileData(format: format)
     }
 }

--- a/Sources/Swim/IO/InscribeImage.swift
+++ b/Sources/Swim/IO/InscribeImage.swift
@@ -1,0 +1,110 @@
+import Foundation
+import CStbImage
+
+// MARK: Utilities
+@inlinable
+func inscribe<P: AlphaImageFileFormat>(image: Image<P, UInt8>) throws -> Data {
+    let width = Int32(image.width)
+    let height = Int32(image.height)
+    let bpp = Int32(P.channels)
+
+    var content = Data()
+    
+    let code = image.data.withUnsafeBufferPointer {
+        write_image_png_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+    }
+
+    guard code != 0 else {
+        throw ImageWriteError.failedToWrite
+    }
+    
+    return content
+}
+
+@inlinable
+func inscribe<P: ImageFileFormat>(image: Image<P, UInt8>, format: WriteFormat) throws -> Data {
+    let width = Int32(image.width)
+    let height = Int32(image.height)
+    let bpp = Int32(P.channels)
+    
+    var content = Data()
+
+    let code: Int32
+    switch format {
+    case .bitmap:
+        code = image.data.withUnsafeBufferPointer {
+            write_image_bmp_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+        }
+    case let .jpeg(quality):
+        guard (1...100).contains(quality) else {
+            throw ImageWriteError.qualityOutOfRange
+        }
+        code = image.data.withUnsafeBufferPointer {
+            write_image_jpg_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!, Int32(quality))
+        }
+    case .png:
+        code = image.data.withUnsafeBufferPointer {
+            write_image_png_to_func(inscribe, &content, width, height, bpp, $0.baseAddress!)
+        }
+    }
+    
+    guard code != 0 else {
+        throw ImageWriteError.failedToWrite
+    }
+    
+    return content
+}
+
+@inlinable
+func inscribe(context: UnsafeMutableRawPointer?, data: UnsafeMutableRawPointer?, size: Int32) -> Void {
+    guard data != nil &&  context != nil else { return }
+
+    let chunk = Data(bytes: data!, count: Int(size))
+
+    let content = context!.assumingMemoryBound(to: Data.self)
+    content.pointee.append(chunk)
+}
+
+// MARK: - UInt8
+extension Image where P: AlphaImageFileFormat, T == UInt8 {
+    /// Returns a `Data` containing representation of the image encoded in PNG format.
+    @inlinable
+    public func inscribe() throws -> Data {
+        try Swim.inscribe(image: self)
+    }
+}
+
+extension Image where P: ImageFileFormat, T == UInt8 {
+    /// Returns a `Data` containing representation of the image encoded in the specified format.
+    ///
+    /// - Parameter format: Image data format. Defaults to PNG.
+    @inlinable
+    public func inscribe(format: WriteFormat = .png) throws -> Data {
+        try Swim.inscribe(image: self, format: format)
+    }
+}
+
+// MARK: - FloatingPoint
+extension Image where P: AlphaImageFileFormat, T: BinaryFloatingPoint {
+    /// Returns a `Data` containing representation of the image encoded in PNG format.
+    ///
+    /// All pixel values are assumed to be in [0, 1] range.
+    /// Values outside the range will be clipped.
+    @inlinable
+    public func inscribe() throws -> Data {
+        return try convertPixelValue(image: self).inscribe()
+    }
+}
+
+extension Image where P: ImageFileFormat, T: BinaryFloatingPoint {
+    /// Returns a `Data` containing representation of the image encoded in the specified format.
+    ///
+    /// All pixel values are assumed to be in [0, 1] range.
+    /// Values outside the range will be clipped.
+    ///
+    /// - Parameter format: Image data format. Defaults to PNG.
+    @inlinable
+    public func inscribe(format: WriteFormat = .png) throws -> Data {
+        return try convertPixelValue(image: self).inscribe(format: format)
+    }
+}

--- a/Sources/Swim/IO/ReadImage.swift
+++ b/Sources/Swim/IO/ReadImage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CStbImage
 
-// MARK: - Utilities
+// MARK: Utilities
 @usableFromInline
 struct STBImageData {
     @usableFromInline var width: Int

--- a/Sources/Swim/IO/WriteImage.swift
+++ b/Sources/Swim/IO/WriteImage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CStbImage
 
-// MARRK: - Protocol
+// MARK: Protocol
 public protocol ImageFileFormat {}
 public protocol AlphaImageFileFormat {}
 
@@ -88,7 +88,7 @@ func detectFormat(url: URL) -> WriteFormat {
 
 // MARK: - UInt8
 extension Image where P: AlphaImageFileFormat, T == UInt8 {
-    /// Save image as PNG file.
+    /// Writes representation of the image to a URL using the PNG format.
     @inlinable
     public func write(to url: URL) throws {
         try Swim.write(image: self, url: url)
@@ -96,7 +96,7 @@ extension Image where P: AlphaImageFileFormat, T == UInt8 {
 }
 
 extension Image where P: ImageFileFormat, T == UInt8 {
-    /// Save image.
+    /// Writes representation of the image to a URL using the format detected from the URL extension.
     ///
     /// File format is automatically decided from pathExtension of url.
     @inlinable
@@ -105,18 +105,19 @@ extension Image where P: ImageFileFormat, T == UInt8 {
         try write(to: url, format: format)
     }
     
-    /// Save image.
+    /// Writes representation of the image to a URL using the specified format.
     ///
-    /// - Parameter format: Image file format. Default: .png
+    /// - Parameter format: Image file format. Defaults to PNG.
     @inlinable
     public func write(to url: URL, format: WriteFormat = .png) throws {
+        let s = ""
         try Swim.write(image: self, url: url, format: format)
     }
 }
 
 // MARK: - FloatingPoint
 extension Image where P: AlphaImageFileFormat, T: BinaryFloatingPoint {
-    /// Save image as PNG file.
+    /// Writes representation of the image to a URL using the PNG format.
     ///
     /// All pixel values are assumed to be in [0, 1] range.
     /// Values outside the range will be clipped.
@@ -127,7 +128,7 @@ extension Image where P: AlphaImageFileFormat, T: BinaryFloatingPoint {
 }
 
 extension Image where P: ImageFileFormat, T: BinaryFloatingPoint {
-    /// Save image.
+    /// Writes representation of the image to a URL using the format detected from the URL extension.
     ///
     /// File format is automatically decided from pathExtension of url.
     ///
@@ -139,12 +140,12 @@ extension Image where P: ImageFileFormat, T: BinaryFloatingPoint {
         try write(to: url, format: format)
     }
     
-    /// Save image.
+    /// Writes representation of the image to a URL using the specified format.
     ///
     /// All pixel values are assumed to be in [0, 1] range.
     /// Values outside the range will be clipped.
     ///
-    /// - Parameter format: Image file format. Default: .png
+    /// - Parameter format: Image file format. Defaults to PNG.
     @inlinable
     public func write(to url: URL, format: WriteFormat = .png) throws {
         return try convertPixelValue(image: self).write(to: url, format: format)

--- a/Tests/SwimTests/IOTests/ImageIOTests.swift
+++ b/Tests/SwimTests/IOTests/ImageIOTests.swift
@@ -142,13 +142,13 @@ class ImageIOTests: XCTestCase {
         }
     }
     
-    func testInscribeUInt8() {
+    func testDataUInt8() {
         do { // RGBA
             let image = self.baseImage!
             
             try! image.write(to: srcPath)
 
-            let data = try! image.inscribe()
+            let data = try! image.fileData()
             
             XCTAssertEqual(data, try! Data(contentsOf: srcPath))
         }
@@ -158,7 +158,7 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
@@ -169,20 +169,20 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
         }
     }
     
-    func testInscribeFloat() {
+    func testDataFloat() {
         do { // RGBA
             let image = (self.baseImage / UInt8.max).cast(to: Float.self)
             
             try! image.write(to: srcPath)
 
-            let data = try! image.inscribe()
+            let data = try! image.fileData()
             
             XCTAssertEqual(data, try! Data(contentsOf: srcPath))
         }
@@ -192,7 +192,7 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
@@ -203,20 +203,20 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
         }
     }
     
-    func testInscribeDouble() {
+    func testDataDouble() {
         do { // RGBA
             let image = (self.baseImage / UInt8.max).cast(to: Double.self)
             
             try! image.write(to: srcPath)
 
-            let data = try! image.inscribe()
+            let data = try! image.fileData()
             
             XCTAssertEqual(data, try! Data(contentsOf: srcPath))
         }
@@ -226,7 +226,7 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
@@ -237,7 +237,7 @@ class ImageIOTests: XCTestCase {
             for format in WriteFormat.all {
                 try! image.write(to: srcPath, format: format)
 
-                let data = try! image.inscribe(format: format)
+                let data = try! image.fileData(format: format)
 
                 XCTAssertEqual(data, try! Data(contentsOf: srcPath))
             }
@@ -248,9 +248,9 @@ class ImageIOTests: XCTestCase {
         ("testSaveLoadUInt8", testSaveLoadUInt8),
         ("testSaveLoadFloat", testSaveLoadFloat),
         ("testSaveLoadDouble", testSaveLoadDouble),
-        ("testInscribeUInt8", testInscribeUInt8),
-        ("testInscribeFloat", testInscribeFloat),
-        ("testInscribeDouble", testInscribeDouble)
+        ("testDataUInt8", testDataUInt8),
+        ("testDataFloat", testDataFloat),
+        ("testDataDouble", testDataDouble)
     ]
 }
 

--- a/Tests/SwimTests/IOTests/ImageIOTests.swift
+++ b/Tests/SwimTests/IOTests/ImageIOTests.swift
@@ -142,9 +142,118 @@ class ImageIOTests: XCTestCase {
         }
     }
     
+    func testInscribeUInt8() {
+        do { // RGBA
+            let image = self.baseImage!
+            
+            try! image.write(to: srcPath)
+
+            let data = try! image.inscribe()
+            
+            XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+        }
+        do { // RGB
+            let image = self.baseImage.toRGB()
+            
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+        do { // Grey
+            let image = self.baseLuminance!
+
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+    }
+    
+    func testInscribeFloat() {
+        do { // RGBA
+            let image = (self.baseImage / UInt8.max).cast(to: Float.self)
+            
+            try! image.write(to: srcPath)
+
+            let data = try! image.inscribe()
+            
+            XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+        }
+        do { // RGB
+            let image = (self.baseImage.toRGB() / UInt8.max).cast(to: Float.self)
+            
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+        do { // Grey
+            let image = (self.baseLuminance / UInt8.max).cast(to: Float.self)
+
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+    }
+    
+    func testInscribeDouble() {
+        do { // RGBA
+            let image = (self.baseImage / UInt8.max).cast(to: Double.self)
+            
+            try! image.write(to: srcPath)
+
+            let data = try! image.inscribe()
+            
+            XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+        }
+        do { // RGB
+            let image = (self.baseImage.toRGB() / UInt8.max).cast(to: Double.self)
+            
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+        do { // Grey
+            let image = (self.baseLuminance / UInt8.max).cast(to: Double.self)
+
+            for format in WriteFormat.all {
+                try! image.write(to: srcPath, format: format)
+
+                let data = try! image.inscribe(format: format)
+
+                XCTAssertEqual(data, try! Data(contentsOf: srcPath))
+            }
+        }
+    }
+    
     static let allTests = [
         ("testSaveLoadUInt8", testSaveLoadUInt8),
         ("testSaveLoadFloat", testSaveLoadFloat),
         ("testSaveLoadDouble", testSaveLoadDouble),
+        ("testInscribeUInt8", testInscribeUInt8),
+        ("testInscribeFloat", testInscribeFloat),
+        ("testInscribeDouble", testInscribeDouble)
     ]
+}
+
+fileprivate extension WriteFormat {
+    static let all: [WriteFormat] = [.bitmap, .jpeg(quality: 90), .png]
 }

--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,10 @@ try image.write(to: dstPath)
 ```
 For reading and writing image, Swim uses [`stb_image.h`](https://github.com/nothings/stb/blob/master/stb_image.h) and [`stb_image_write.h`](https://github.com/nothings/stb/blob/master/stb_image_write.h).
 
-#### Inscribe to a `Data` BLOB
+#### Save image to a `Data` BLOB
 ```swift
 let image = Image<RGB, UInt8>(width: 32, height: 32, color: Color.red)
-let data = try image.inscribe(format: .jpeg(quality: 80))
+let data = try image.fileData(format: .jpeg(quality: 80))
 ```
 
 ### Platform specific operations

--- a/readme.md
+++ b/readme.md
@@ -31,13 +31,20 @@ let zero = Image<RGBA, Double>(width: 3, height: 4, value: 0)
 let red = Image<RGBA, Double>(width: 3, height: 5, color: Color(r: 1, g: 0, b: 0, a: 1))
 ```
 
-### Save/Load image
+### Input and output
+
+#### Save and load from a file
 ```swift
 let image = try Image<RGBA, UInt8>(contentsOf: url)
-try image.write(path: dstPath)
+try image.write(to: dstPath)
 ```
+For reading and writing image, Swim uses [`stb_image.h`](https://github.com/nothings/stb/blob/master/stb_image.h) and [`stb_image_write.h`](https://github.com/nothings/stb/blob/master/stb_image_write.h).
 
-For reading and writing image, Swim uses [stb_image.h](https://github.com/nothings/stb/blob/master/stb_image.h) and [stb_image_write.h](https://github.com/nothings/stb/blob/master/stb_image_write.h).
+#### Inscribe to a `Data` BLOB
+```swift
+let image = Image<RGB, UInt8>(width: 32, height: 32, color: Color.red)
+let data = try image.inscribe(format: .jpeg(quality: 80))
+```
 
 ### Platform specific operations
 ```swift
@@ -254,7 +261,7 @@ let reconstruct = converter.demosaic(image: bayer)
 
 ![bayer_bggr](https://user-images.githubusercontent.com/12446914/56634959-cce5f800-669e-11e9-89a2-ce49121a44bc.png)
 
-## Application exapmles
+## Application examples
 
 - [Template matching](https://github.com/t-ae/swim/blob/99e7be2655057190b62426cdb85fe56b130d7126/Tests/VisualTests/ApplicationVisualTests.swift#L340-L414)
 - [Canny edge detection](https://github.com/t-ae/swim/blob/99e7be2655057190b62426cdb85fe56b130d7126/Tests/VisualTests/ApplicationVisualTests.swift#L226-L338)


### PR DESCRIPTION
Hello @t-ae ,

I implemented a change that adds a method for encoding an image to a specific format purely in-memory, without writing a temporary file. Signature of the method is `Image.inscribe(format:)` and it returns the image in the given format as a `Data` BLOB.

To explain it better here's an example use of the new method:
```swift
let image = Image<RGB, UInt8>(width: 32, height: 32, color: .red)
let data = try image.inscribe(format: .jpeg(quality: 80))
```

PS: There's also a few documentation improvements and typo fixes sprinkled throughout the commits...


### Motivation

I believe the feature has many more use cases but I ended up needing it in order to create two specific things. 

First, a video from a collection of `Image` frames. It's much faster to encode the video purely in-memory without storing any temporary files. Especially for longer videos there's also a significant disk space saving. The solution I used in my case is to pipe the individual frames to FFmpeg subprocess. FFmpeg encodes the video on the fly and pipes the chunks back to the main application via stdout.

Second, I wanted to display the `Image` in Colab/Jupyter notebook. The protocol requires the image to be transported in a JSON-able format. So the raw bytes need to be base64 encoded. Again it is easier and faster without a temporary file.


### Naming

Naming is hard... Any suggestions for improvements are welcome. Besides the `Image.inscribe(...)` I also considered using `Image.data(...) signature`. Personally, I like the `.data(...)` option a bit more. It is very similar to what people are used from the Foundation library. Specifically, when one wants binary `Data` representation of a `String` then the method that does the job is `String.data(using:)`.

Unfortunately, `Image.data` is already taken for actual pixels. Even though it's not declared as a public property it is used almost everywhere throughout the codebase. So renaming it to something else just to make room for my small improvement isn't a good idea.


### Implementation

Under the hood, `Image.inscribe(...)` uses the `stbi_write_*_to_func(...)` family of C functions. These functions accept a pointer to a writing callback instead of the filename. Thanks to the interoperability with C, the writing callback can be implemented in Swift. The closure keeps receiving raw byte chunks and gradually builds the `Data` BLOB buffer that eventually holds the entire image encoded in the desired file format.
